### PR TITLE
Updating year instance, Sapphire Rapids, RDS Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Intel® Optimized Cloud Modules for Terraform
 
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## AWS RDS Postgresql module
 
@@ -30,8 +30,8 @@ Within the main.tf aws_db_instance resource block, edit the parameter_group_name
 resource "aws_db_instance" "example" {
   identifier                = "my-postgresql-db"
   engine                    = "postgres"
-  engine_version            = "14.7"
-  instance_class            = "db.m5i.large"
+  engine_version            = "14.15" # Upgraded from 14.07 to 14.15
+  instance_class            = "db.m7i.large"
   allocated_storage         = 20
   storage_type              = "gp2"
   publicly_accessible       = false

--- a/examples/create-parameters/README.md
+++ b/examples/create-parameters/README.md
@@ -4,7 +4,7 @@
 
 # Intel® Optimized Cloud Modules for Terraform
 
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## AWS RDS PostgreSQL Parameters Group
 

--- a/examples/create-parameters/main.tf
+++ b/examples/create-parameters/main.tf
@@ -2,6 +2,5 @@
 
 # Provision Intel Optimized AWS MSSQL server
 module "aws-postgresql-parameter-group" {
-  #source = "intel/terraform-intel-aws-postgresql-parameter/intel"
-  source = "../../"
+  source = "intel/terraform-intel-aws-postgresql-parameter/intel"
 }

--- a/examples/existing-module/README.md
+++ b/examples/existing-module/README.md
@@ -4,7 +4,7 @@
 
 # Intel® Optimized Cloud Modules for Terraform
 
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## AWS RDS MySQL Parameters Group
 
@@ -15,6 +15,7 @@ This example module will create a PostgreSQL RDS instance with the parameters gr
 main.tf
 
 ```hcl
+db_password
 
 # Provision Intel Optimized AWS MySQL server
 
@@ -28,8 +29,8 @@ module "aws-postgresql-parameter-group" {
 resource "aws_db_instance" "example" {
   identifier                = "my-postgresql-db"
   engine                    = "postgres"
-  engine_version            = "14.7"
-  instance_class            = "db.m5i.large"
+  engine_version       = "14.15" # Changing from 14.07 from 14.15
+  instance_class       = "db.m7i.large"
   allocated_storage         = 20
   storage_type              = "gp2"
   publicly_accessible       = false

--- a/examples/existing-module/main.tf
+++ b/examples/existing-module/main.tf
@@ -12,8 +12,8 @@ resource "aws_db_instance" "postgresql" {
   db_name              = "postgresdb"
   identifier           = "postgresql-intel-optimized"
   engine               = "postgres"
-  engine_version       = "14.7"
-  instance_class       = "db.m6i.large"
+  engine_version       = "14.15" # Changing from 14.07 from 14.15
+  instance_class       = "db.m7i.large"
   username             = "admin25"
   password             = "var.db_password"
   parameter_group_name = module.aws-postgresql-parameter-group.db_parameter_group_name

--- a/policies.md
+++ b/policies.md
@@ -4,7 +4,7 @@
 
 # Intel® Optimized Cloud Modules for Terraform  
 
-© Copyright 2024, Intel Corporation
+© Copyright 2025, Intel Corporation
 
 ## HashiCorp Sentinel Policies
 


### PR DESCRIPTION
- Year instance from 2024 to 2025
- 3rd generation to 4th generation (db.m7i now supported over db.m5i)
- Need to update marketing material to Sapphire Rapids
- RDS instance 14.15 supported over 14.7. 14.7 is not supported anymore. Note that AWS supports 15 and 16 family but module is being built on postgres14 family